### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/mahata/react-vite-template/security/code-scanning/1](https://github.com/mahata/react-vite-template/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the workflow's operations, such as checking out the code and running tests. This change adheres to the principle of least privilege by restricting the `GITHUB_TOKEN` to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
